### PR TITLE
Alternative: useReducer + useContext

### DIFF
--- a/src/App.hooks.js
+++ b/src/App.hooks.js
@@ -4,13 +4,9 @@ import Box from "./Box";
 function App() {
   const [isYellow, setIsYellow] = useState(true);
 
-  // handleClick requires information from the current state to do its work.
-  // This means that everytime state changes a new handler is created
-  // This is incredibly common that a handler needs to know something about
-  // the state of the component.
   const handleClick = useCallback(() => {
-    setIsYellow(!isYellow);
-  }, [isYellow]);
+    setIsYellow(isYellow => !isYellow);
+  }, []);
 
   return (
     <>

--- a/src/App.hooks.js
+++ b/src/App.hooks.js
@@ -1,18 +1,22 @@
-import React, { useCallback, useState } from "react";
+import React, { useReducer } from "react";
 import Box from "./Box";
+import AppContext from './AppContext';
+
+function reducer(state, action) {
+  if (action === 'toggle') {
+    return !state;
+  }
+  throw new Error();
+}
 
 function App() {
-  const [isYellow, setIsYellow] = useState(true);
-
-  const handleClick = useCallback(() => {
-    setIsYellow(isYellow => !isYellow);
-  }, []);
+  const [isYellow, dispatch] = useReducer(reducer, true);
 
   return (
-    <>
+    <AppContext.Provider value={dispatch}>
       <h1>App.hooks.js</h1>
-      <Box isYellow={isYellow} depth={12} onClick={handleClick} />
-    </>
+      <Box isYellow={isYellow} depth={12} />
+    </AppContext.Provider>
   );
 }
 

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,0 +1,3 @@
+import {createContext} from 'react';
+
+export default createContext();

--- a/src/Box.js
+++ b/src/Box.js
@@ -17,14 +17,14 @@ const row = {
   display: "flex",
   flexDirection: "row"
 };
-const Box = ({ depth = 0, isYellow, onClick }) => {
+const Box = ({ depth = 0, isYellow }) => {
   return (
     <div style={isYellow ? yellow : white}>
-      <Button onClick={onClick} />
+      <Button />
       {depth > 0 ? (
         <div style={row}>
-          <Box isYellow={isYellow} depth={depth - 1} onClick={onClick} />
-          <Box isYellow={isYellow} depth={depth - 1} onClick={onClick} />
+          <Box isYellow={isYellow} depth={depth - 1} />
+          <Box isYellow={isYellow} depth={depth - 1} />
         </div>
       ) : null}
     </div>

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,4 +1,5 @@
-import React, { memo } from "react";
+import React, { memo, useContext, useCallback } from "react";
+import AppContext from './AppContext';
 
 const style = {
   cursor: "pointer",
@@ -7,11 +8,17 @@ const style = {
   height: "7.69vh"
 };
 
-export default memo(({ onClick }) => {
+export default memo(() => {
+  const dispatch = useContext(AppContext);
+
+  const handleClick = useCallback(() => {
+    dispatch('toggle');
+  }, []);
+
   // do some expensive work calculating the button guarded by the memo
   let work = 0.5;
   for (let i = 0; i < 10000; i++) {
     work = (work + Math.random()) / 2;
   }
-  return <div style={style} onClick={onClick} />;
+  return <div style={style} onClick={handleClick} />;
 });


### PR DESCRIPTION
This is meant to demonstrate an alternative to https://github.com/ryardley/hooks-perf-issues/pull/2 which might make sense for larger apps. It helps you avoid the need for passing callbacks altogether which alleviates most of these concerns. The reducer form is also more flexible because you can use other state variables, or even props (by putting reducer itself inline into the component).

See https://reactjs.org/docs/hooks-faq.html#how-to-avoid-passing-callbacks-down